### PR TITLE
Set RAILS_ENV to test during spec run.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start 'rails'
 SimpleCov.add_filter 'app/admin'
 
+ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 


### PR DESCRIPTION
Currently the development DB is wiped out by a spec run, causing devs to
have to `rake db:seed` to continue development work.
